### PR TITLE
Support Laravel 10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
         laravel: ['5.5', '5.6', '5.7', '5.8', '6', '7', '8', '9']
         exclude:
           - php: '7.1'
@@ -50,6 +50,20 @@ jobs:
             laravel: '6'
           - php: '8.1'
             laravel: '7'
+          - php: '8.2'
+            laravel: '5.5'
+          - php: '8.2'
+            laravel: '5.6'
+          - php: '8.2'
+            laravel: '5.7'
+          - php: '8.2'
+            laravel: '5.8'
+          - php: '8.2'
+            laravel: '6'
+          - php: '8.2'
+            laravel: '7'
+          - php: '8.2'
+            laravel: '8'
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
-        laravel: ['5.5', '5.6', '5.7', '5.8', '6', '7', '8', '9']
+        laravel: ['5.5', '5.6', '5.7', '5.8', '6', '7', '8', '9', '10']
         exclude:
           - php: '7.1'
             laravel: '6'
@@ -22,14 +22,22 @@ jobs:
             laravel: '8'
           - php: '7.1'
             laravel: '9'
+          - php: '7.1'
+            laravel: '10'
           - php: '7.2'
             laravel: '8'
           - php: '7.2'
             laravel: '9'
+          - php: '7.2'
+            laravel: '10'
           - php: '7.3'
             laravel: '9'
+          - php: '7.3'
+            laravel: '10'
           - php: '7.4'
             laravel: '9'
+          - php: '7.4'
+            laravel: '10'
           - php: '8.0'
             laravel: '5.5'
           - php: '8.0'
@@ -38,6 +46,8 @@ jobs:
             laravel: '5.7'
           - php: '8.0'
             laravel: '5.8'
+          - php: '8.0'
+            laravel: '10'
           - php: '8.1'
             laravel: '5.5'
           - php: '8.1'
@@ -132,7 +142,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require "laravel/framework:8.*" "phpunit/phpunit:^9.3|^10.0" --no-update --no-interaction
+          command: composer require "laravel/framework:8.*" "phpunit/phpunit:^9.3" --no-update --no-interaction
         if: "matrix.laravel == '8'"
 
       - name: Select Laravel 9
@@ -140,8 +150,16 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require "laravel/framework:9.*" "phpunit/phpunit:^9.5|^10.0" --no-update --no-interaction
+          command: composer require "laravel/framework:9.*" "phpunit/phpunit:^9.5" --no-update --no-interaction
         if: "matrix.laravel == '9'"
+
+      - name: Select Laravel 10
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer require "laravel/framework:10.*" "phpunit/phpunit:^9.6|^10.0" --no-update --no-interaction
+        if: "matrix.laravel == '10'"
 
       - name: Install PHP Dependencies
         uses: nick-invision/retry@v2

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Laravel TestBench was created by, and is maintained by [Graham Campbell](https:/
 
 ## Installation
 
-This version requires [PHP](https://www.php.net/) 7.1-8.2 and supports [PHPUnit](https://phpunit.de/) 6-10 and [Laravel](https://laravel.com/) 5.5-9.
+This version requires [PHP](https://www.php.net/) 7.1-8.2 and supports [PHPUnit](https://phpunit.de/) 6-10 and [Laravel](https://laravel.com/) 5.5-10.
 
-| TestBench | L5.1               | L5.2               | L5.3               | L5.5               | L5.5               | L5.6               | L5.7               | L5.8               | L6                 | L7                 | L8                 | L9                 |
-|-----------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
-| 3.4       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                |
-| 4.0       | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                |
-| 5.7       | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| TestBench | L5.1               | L5.2               | L5.3               | L5.5               | L5.5               | L5.6               | L5.7               | L5.8               | L6                 | L7                 | L8                 | L9                 | L10                |
+|-----------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
+| 3.4       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                |
+| 4.0       | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                |
+| 5.7       | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 | TestBench | PHPUnit 4.8        | PHPUnit 5          | PHPUnit 6          | PHPUnit 7          | PHPUnit 8          | PHPUnit 9          | PHPUnit 10         |
 |-----------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Laravel TestBench was created by, and is maintained by [Graham Campbell](https:/
 
 ## Installation
 
-This version requires [PHP](https://www.php.net/) 7.1-8.1 and supports [PHPUnit](https://phpunit.de/) 6-10 and [Laravel](https://laravel.com/) 5.5-9.
+This version requires [PHP](https://www.php.net/) 7.1-8.2 and supports [PHPUnit](https://phpunit.de/) 6-10 and [Laravel](https://laravel.com/) 5.5-9.
 
 | TestBench | L5.1               | L5.2               | L5.3               | L5.5               | L5.5               | L5.6               | L5.7               | L5.8               | L6                 | L7                 | L8                 | L9                 |
 |-----------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     "require": {
         "php": "^7.1.3 || ^8.0",
         "graham-campbell/testbench-core": "^3.4",
-        "orchestra/testbench": "^3.5 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
+        "orchestra/testbench": "^3.5 || ^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "graham-campbell/analyzer": "^2.4 || ^3.0",
         "mockery/mockery": "^1.3.1",
-        "phpunit/phpunit": "^6.5 || ^7.5 || ^8.0 || ^9.0 || 10.0"
+        "phpunit/phpunit": "^6.5 || ^7.5 || ^8.0 || ^9.0 || ^10.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Requires #30 

Resolves #29

Adds Laravel 10 to the GitHub tests workflow; also marks PHPUnit 10 as only compatible with Laravel 10.