### PR TITLE
Add allow-plugins section to composer.json to fix workflow

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,10 @@
         }
     },
     "config": {
-        "preferred-install": "dist"
+        "preferred-install": "dist",
+        "allow-plugins": {
+            "kylekatarnls/update-helper": false
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true


### PR DESCRIPTION
Workflows are currently failing due to Composer requiring an explicit list `allow-plugins` as of v2.2. This MR fixes this issue by explicitly listing it.

Note: I have chosen `false` as the safest option to start with and workflows seem to be fine with that: see https://github.com/jnoordsij/Laravel-TestBench/actions/runs/4122641824.