### PR TITLE
Added missing function parameters

### DIFF
--- a/src/AbstractPackageTestCase.php
+++ b/src/AbstractPackageTestCase.php
@@ -75,9 +75,11 @@ abstract class AbstractPackageTestCase extends TestCase
     /**
      * Get the required service providers.
      *
+     * @param \Illuminate\Contracts\Foundation\Application $app
+     *
      * @return string[]
      */
-    protected static function getRequiredServiceProviders(): array
+    protected static function getRequiredServiceProviders($app): array
     {
         return [];
     }
@@ -85,12 +87,14 @@ abstract class AbstractPackageTestCase extends TestCase
     /**
      * Get the service provider class.
      *
+     * @param \Illuminate\Contracts\Foundation\Application $app
+     *
      * @return string
      */
-    protected static function getServiceProviderClass(): string
+    protected static function getServiceProviderClass($app): string
     {
-        // this may be overwritten, and must be overwritten
-        // if used with the service provider test case trait
+        // This may be overwritten, and must be overwritten
+        // if used with the service provider test case trait.
         return '';
     }
 }


### PR DESCRIPTION
Hi!

Upon upgrading to a new version of Laravel, I discovered that the signature of these methods has changed, but it seems that some of the parameters are simply missing, given that the arguments are still passed into the calls above.